### PR TITLE
Update httpurllib.py

### DIFF
--- a/BuildSimHubAPI/helpers/httpurllib.py
+++ b/BuildSimHubAPI/helpers/httpurllib.py
@@ -170,11 +170,14 @@ def __encode_multipart_formdata(params, files):
         if isinstance(l, bytes):
             body += l + b'\r\n'
         else:
-            body += bytes(str(l), encoding='utf8') + b'\r\n'
+            try:
+                body += bytes(str(l), encoding='utf8') + b'\r\n'
+            except:
+                body += bytes(l) + b'\r\n'
 
     headers = {'Content-Type' : 'multipart/form-data; boundary=' + boundry}
 
-    return headers, body
+    return headers, str(body)
 
 
 def request_large_data(path, params):


### PR DESCRIPTION
For HTTPConnection.request(method, url[, body[, headers]]) in Python2.7, the body should be a string of data to send. But in Python3.7, which is the current function is based on, the body could be a string, bytes, or even files, depending on the contect. As there might be some unnormal symbols in the idf or gbXML file, Haopeng perviously used bytes to send.